### PR TITLE
Allow real usage of Accept header on iOS

### DIFF
--- a/src/ios/CordovaHttpPlugin.m
+++ b/src/ios/CordovaHttpPlugin.m
@@ -79,7 +79,7 @@
    [self setRequestHeaders: headers];
    
    CordovaHttpPlugin* __weak weakSelf = self;
-   manager.responseSerializer = [TextResponseSerializer serializer];
+   manager.responseSerializer = [TextResponseSerializer serializer: headers];
    [manager POST:url parameters:parameters success:^(AFHTTPRequestOperation *operation, id responseObject) {
       NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
       [dictionary setObject:[NSNumber numberWithInt:operation.response.statusCode] forKey:@"status"];
@@ -109,7 +109,7 @@
    
    CordovaHttpPlugin* __weak weakSelf = self;
    
-   manager.responseSerializer = [TextResponseSerializer serializer];
+   manager.responseSerializer = [TextResponseSerializer serializer: headers];
    [manager GET:url parameters:parameters success:^(AFHTTPRequestOperation *operation, id responseObject) {
       NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
       [dictionary setObject:[NSNumber numberWithInt:operation.response.statusCode] forKey:@"status"];
@@ -139,7 +139,7 @@
    
    CordovaHttpPlugin* __weak weakSelf = self;
    
-   manager.responseSerializer = [TextResponseSerializer serializer];
+   manager.responseSerializer = [TextResponseSerializer serializer: headers];
    [manager PUT:url parameters:parameters success:^(AFHTTPRequestOperation *operation, id responseObject) {
       NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
       [dictionary setObject:[NSNumber numberWithInt:operation.response.statusCode] forKey:@"status"];
@@ -169,7 +169,7 @@
    
    CordovaHttpPlugin* __weak weakSelf = self;
    
-   manager.responseSerializer = [TextResponseSerializer serializer];
+   manager.responseSerializer = [TextResponseSerializer serializer: headers];
    [manager DELETE:url parameters:parameters success:^(AFHTTPRequestOperation *operation, id responseObject) {
       NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
       [dictionary setObject:[NSNumber numberWithInt:operation.response.statusCode] forKey:@"status"];
@@ -205,7 +205,7 @@
     [self setRequestHeaders: headers];
     
     CordovaHttpPlugin* __weak weakSelf = self;
-    manager.responseSerializer = [TextResponseSerializer serializer];
+    manager.responseSerializer = [TextResponseSerializer serializer: headers];
     [manager POST:url parameters:parameters constructingBodyWithBlock:^(id<AFMultipartFormData> formData) {
         NSError *error;
         [formData appendPartWithFileURL:fileURL name:name error:&error];

--- a/src/ios/TextResponseSerializer.h
+++ b/src/ios/TextResponseSerializer.h
@@ -3,6 +3,6 @@
 
 @interface TextResponseSerializer : AFHTTPResponseSerializer
 
-+ (instancetype)serializer;
++ (instancetype)serializer:(NSDictionary*)headers;
 
 @end

--- a/src/ios/TextResponseSerializer.m
+++ b/src/ios/TextResponseSerializer.m
@@ -12,18 +12,25 @@ static BOOL AFErrorOrUnderlyingErrorHasCode(NSError *error, NSInteger code) {
 
 @implementation TextResponseSerializer
 
-+ (instancetype)serializer {
-    TextResponseSerializer *serializer = [[self alloc] init];
++ (instancetype)serializer:(NSDictionary *)headers {
+    TextResponseSerializer *serializer = [[self alloc] init: headers];
     return serializer;
 }
 
-- (instancetype)init {
+- (instancetype)init:(NSDictionary *)headers {
     self = [super init];
     if (!self) {
         return nil;
     }
 
     self.acceptableContentTypes = [NSSet setWithObjects:@"text/plain", @"text/html", @"text/json", @"application/json", @"text/xml", @"application/xml", @"text/css", nil];
+
+    if ([headers objectForKey:@"Accept"]) {
+        NSString *acceptHeader = [headers valueForKeyPath:@"Accept"];
+        acceptHeader = [acceptHeader stringByReplacingOccurrencesOfString:@" " withString:@""];
+        NSArray *acceptHeaderList = [acceptHeader componentsSeparatedByString:@","];
+        self.acceptableContentTypes = [self.acceptableContentTypes setByAddingObjectsFromArray:acceptHeaderList];
+    }
 
     return self;
 }


### PR DESCRIPTION
Extended the set of acceptableContentTypes on iOS when an Accept header is passed
